### PR TITLE
Remove camel case rule that was causing issue with smartpension eslin…

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,9 +8,6 @@ module.exports = {
     'new-cap': 'off',
     'babel/new-cap': baseStyle.rules['new-cap'],
 
-    camelcase: 'off',
-    'babel/camelcase': baseStyle.rules.camelcase,
-
     'no-invalid-this': 'off',
     'babel/no-invalid-this': baseBestPractices.rules['no-invalid-this'],
 


### PR DESCRIPTION
Removed the `camelcase` rule that was causing an error (see below) when used with the [smartpension/eslint-config](https://github.com/smartpension/eslint-config) package on a non Typescript project

Error:
```
Configuration for rule "babel/camelcase" is invalid:
	Value {"properties":"never","ignoreDestructuring":false,"ignoreImports":false} should NOT have additional properties.
```