### PR TITLE
Upgrade eslint-config-airbnb-base to 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "url": "https://github.com/davidjbradshaw/eslint-config-airbnb-babel.git"
     },
     "dependencies": {
-        "eslint-config-airbnb-base": "^14.2.0"
+        "eslint-config-airbnb-base": "^15.0.0"
     },
     "devDependencies": {
         "eslint": "^7",


### PR DESCRIPTION
Upgrade eslint-config-airbnb-base to 15 in order to support eslint 8.x